### PR TITLE
Establish /products endpoint with getAllProducts helper

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,11 +1,16 @@
 require('dotenv').config();
 const express = require('express');
+const db = require('./psql/models.js');
 const app = express();
 app.use(express.json());
 
 app.get('/products', (req, res) => {
-  // TODO
-  res.send();
+  let { page, count } = req.query;
+  page = page || 1;
+  count = count || 5;
+  db.getAllProducts(page, count)
+    .then(results => res.send(results))
+    .catch(error => res.send(error));
 });
 
 app.get('/products/:product_id', (req, res) => {

--- a/server/psql/index.js
+++ b/server/psql/index.js
@@ -1,8 +1,13 @@
+require('dotenv').config();
 const { Client } = require('pg');
 
-const client = new Client();
+const client = new Client({
+  database: 'product_overview',
+});
 
 client
   .connect()
   .then(() => console.log('PostgreSQL database connection established!'))
   .catch((err) => console.log('PostgreSQL database connection error', err.stack));
+
+module.exports.client = client;

--- a/server/psql/models.js
+++ b/server/psql/models.js
@@ -1,0 +1,21 @@
+const db = require('./index.js');
+
+module.exports = {
+  getAllProducts: (page, count) => {
+    let offset = (page - 1) * count;
+    let queryString = 'SELECT * FROM products OFFSET $1 LIMIT $2';
+    let values = [offset, count];
+    return db.client
+      .query(queryString, values)
+      .then(results => results.rows)
+      .catch(error => error);
+  },
+  getProductById: (productId) => {
+    let queryString = 'SELECT * FROM products WHERE id = $1';
+    let values = [productId];
+    return db.client
+      .query(queryString, values)
+      .then(results => console.log('results: ', results))
+      .catch(error => console.log('error: ', error));
+  }
+};


### PR DESCRIPTION
Summary:
- Made some changes to how a client is connected to PostgreSQL
- Created getAllProducts helper/model to query all products depending on the provided page and count
- Created getProductById helper/model (still work-in-progress)
- Modified server/index.js to utilize the helper(s) to return appropriate response

Note:
- This PR does not include unit tests to check the functionality of the helper(s) .
-  /products endpoint still needs some fine-tuning. Currently, the queried result doesn't start at product_id 1. I'm working on a way to resolve this bug.
- .env file is not working as expected for PostgreSQL connection. Will revisit this issue again but currently not high priority.